### PR TITLE
use eza instead of exa

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -81,9 +81,9 @@ setopt hist_reduce_blanks  # ヒストリに保存するときに余分なスペ
 ########################################
 # Aliases
 
-alias ls='exa'
-alias ll='exa -hl --git'
-alias la='exa -ahl --git'
+alias ls='eza'
+alias ll='eza -hl --git'
+alias la='eza -ahl --git'
 
 # Always enable colored `grep` output
 # Note: `GREP_OPTIONS="--color=auto"` is deprecated, hence the alias usage.

--- a/Brewfile
+++ b/Brewfile
@@ -2,7 +2,7 @@ tap "homebrew/cask"
 cask_args appdir: "/Applications"
 
 brew "bat"
-brew "exa"
+brew "eza"
 brew "fd"
 brew "gibo"
 brew "git"


### PR DESCRIPTION
Because exa is unmaintained.
- https://github.com/ogham/exa/issues/1243
- https://shoalwave.net/develop/2023100406414/