### PR TITLE
chore: update app list and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# dotfiles
+
+A repository to automate macOS setup from scratch.
+
+## File Structure
+
+- `Brewfile` — Manages everything installed via Homebrew (brew, cask, mas)
+- `README.md` — Lists apps that require manual download (not available via Homebrew)
+- `install_mac.sh` — macOS setup script (Xcode, Homebrew, Brewfile, macOS defaults)
+- `install_any.sh` — Entry point that detects the OS and calls install_mac.sh
+
+## Editing Rules
+
+- Anything installable via Homebrew goes in Brewfile. Do not add it to README.md.
+- Only apps that require manual download should be listed in the "by Download" section of README.md.
+- Avoid duplicate entries across files when adding or removing items.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ $ sh ./install.sh
 
 - 1Password
 - (any AI Browser like ChatGPT Atlas)
-- Alfred(Registered)
 - Cursor
 - Dash
 - Docker
@@ -23,9 +22,6 @@ $ sh ./install.sh
 - Google Chrome
 - Google 日本語入力
 - HyperSwitch
-- LibreOffice
-- OWASP ZAP
 - Scroll Reverser
 - Visual Studio Code
 - Warp
-- Wireshark


### PR DESCRIPTION
## Summary

- Remove Alfred from README.md (replaced by Raycast, which is already in Brewfile)
- Remove LibreOffice, OWASP ZAP, and Wireshark from README.md (no longer in use)
- Add CLAUDE.md with repository purpose, file structure, and editing rules

🤖 Generated with [Claude](https://claude.ai)